### PR TITLE
First cut at centralizing device support info.

### DIFF
--- a/SupportedDevices.md
+++ b/SupportedDevices.md
@@ -1,0 +1,20 @@
+| Brand     | Model         | Android Version   | v1 Goggles    | v2 Goggles    | 25mbit    | 50mbit    | Latency   | Notes |
+| -         | -             | -                 | -             | -             | -         | -         | -         | - |
+| Nokia     | 5.1 Plus      | 10                | Yes           | Unknown       | Yes       | Yes       | ~200ms    ||
+| Samsung   | Galaxy S20    | Latest            | Yes           | Unknown       | No        | Yes       | Fast      ||
+| Samsung   | S7 Edge       | 8.0.0             | Unknown       | Yes           | Unknown   | Yes       | ~220ms    ||
+| Google    | Pixel 4XL     | 11                | Yes           | Unknown       | Unknown   | Yes       | ~150ms    ||
+| Essential | PH-1          | 10                | Yes           | Unknown       | No        | Yes       | 200-2000ms||
+| Samsung   | S20 5G        | 11                | Yes           | Unknown       | No        | Yes       | 200-300ms ||
+| Fairphone | 3             | 10                | Unknown       | Yes           | Yes       | Unknown   | 5+ seconds||
+| Samsung   | Galaxy S8     | Unknown           | Yes           | Unknown       | Unknown   | Yes       | Unknown   ||
+| Huawei    | P30 Pro       | 10.1              | Yes           | Unknown       | No        | No        | Unknown   ||
+| LG        | Nexus 5x      | 8.1               | Unknown       | Yes           | Unknown   | Yes       | 600+ms    ||
+| Samsung   | Galaxy S9     | 10                | Yes           | Unknown       | Unknown   | Yes       | High, then low | Occasionally freezes
+| OnePlus   | Nord N10 5G   | 10                | Yes           | Unknown       | Yes       | Yes       | 100-200ms ||
+| Samsung   | Note 9        | 10                | Yes           | Unknown       | Unknown   | Yes       | ~150ms||
+| OnePlus   | 8 Pro         | 11                | Unknown       | Yes           | No        | Yes       | ~180ms ||
+| Samsung   | S10+ 5G       | 11                | Yes           | Unknown       | Yes       | Yes       | ~500ms ||
+| OnePlus   | 7T            | 10                | Yes           | Unknown       | Unknown   | Yes       | ~150ms    | Sometimes it works very well. Most of the times it shows a few frames at high speed and then freezes or shows frames at a very low rate. Changing cables didn't seem to help it.|
+| Samsung   | Galaxy S7 (not edge)| 8.0.0       | Unknown       | Yes           | Unknown   | Yes       | ~200ms ||
+| Samsung   | S7            | 8.0               | Yes           | Unknown       | Yes       | Yes       | <1s||


### PR DESCRIPTION
 Should go into a db eventually, because curating markdown by hand is a pain.

This is related to #14, but I'm too dumb to figure out how to associate a PR to an issue.