### PR TITLE
Video aspect-fit to native ratio, toggle with double tap/pinch

### DIFF
--- a/app/src/main/java/com/fpvout/digiview/MainActivity.java
+++ b/app/src/main/java/com/fpvout/digiview/MainActivity.java
@@ -5,6 +5,7 @@ import androidx.appcompat.app.AppCompatActivity;
 
 import android.animation.Animator;
 import android.animation.AnimatorListenerAdapter;
+import android.animation.LayoutTransition;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
@@ -13,9 +14,11 @@ import android.hardware.usb.UsbDevice;
 import android.hardware.usb.UsbManager;
 import android.os.Bundle;
 import android.util.Log;
+import android.view.GestureDetector;
 import android.view.MotionEvent;
 import android.view.SurfaceView;
 import android.view.View;
+import android.view.ViewGroup;
 import android.view.WindowManager;
 import android.widget.Toast;
 
@@ -37,6 +40,7 @@ public class MainActivity extends AppCompatActivity implements UsbDeviceListener
     VideoReaderExoplayer mVideoReader;
     boolean usbConnected = false;
     SurfaceView fpvView;
+    GestureDetector gestureDetector;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -73,6 +77,23 @@ public class MainActivity extends AppCompatActivity implements UsbDeviceListener
         watermarkView = findViewById(R.id.watermarkView);
         fpvView = findViewById(R.id.fpvView);
 
+        // Enable resizing animations
+        ((ViewGroup)findViewById(R.id.mainLayout)).getLayoutTransition().enableTransitionType(LayoutTransition.CHANGING);
+
+        gestureDetector = new GestureDetector(this, new GestureDetector.SimpleOnGestureListener() {
+            @Override
+            public boolean onSingleTapConfirmed(MotionEvent e) {
+                toggleWatermark();
+                return super.onSingleTapConfirmed(e);
+            }
+
+            @Override
+            public boolean onDoubleTap(MotionEvent e) {
+                mVideoReader.toggleZoom();
+                return super.onDoubleTap(e);
+            }
+        });
+
         mUsbMaskConnection = new UsbMaskConnection();
         mVideoReader = new VideoReaderExoplayer(fpvView, this);
 
@@ -87,9 +108,7 @@ public class MainActivity extends AppCompatActivity implements UsbDeviceListener
 
     @Override
     public boolean onTouchEvent(MotionEvent event) {
-        if (event.getAction() == MotionEvent.ACTION_UP) {
-            toggleWatermark();
-        }
+        gestureDetector.onTouchEvent(event);
 
         return super.onTouchEvent(event);
     }

--- a/app/src/main/java/com/fpvout/digiview/MainActivity.java
+++ b/app/src/main/java/com/fpvout/digiview/MainActivity.java
@@ -40,7 +40,7 @@ public class MainActivity extends AppCompatActivity implements UsbDeviceListener
     VideoReaderExoplayer mVideoReader;
     boolean usbConnected = false;
     SurfaceView fpvView;
-    GestureDetector gestureDetector;
+    private GestureDetector gestureDetector;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {

--- a/app/src/main/java/com/fpvout/digiview/MainActivity.java
+++ b/app/src/main/java/com/fpvout/digiview/MainActivity.java
@@ -16,6 +16,7 @@ import android.os.Bundle;
 import android.util.Log;
 import android.view.GestureDetector;
 import android.view.MotionEvent;
+import android.view.ScaleGestureDetector;
 import android.view.SurfaceView;
 import android.view.View;
 import android.view.ViewGroup;
@@ -41,6 +42,7 @@ public class MainActivity extends AppCompatActivity implements UsbDeviceListener
     boolean usbConnected = false;
     SurfaceView fpvView;
     private GestureDetector gestureDetector;
+    private ScaleGestureDetector scaleGestureDetector;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -94,6 +96,17 @@ public class MainActivity extends AppCompatActivity implements UsbDeviceListener
             }
         });
 
+        scaleGestureDetector = new ScaleGestureDetector(this, new ScaleGestureDetector.SimpleOnScaleGestureListener() {
+            @Override
+            public void onScaleEnd(ScaleGestureDetector detector) {
+                if (detector.getScaleFactor() < 1) {
+                    mVideoReader.zoomOut();
+                } else {
+                    mVideoReader.zoomIn();
+                }
+            }
+        });
+
         mUsbMaskConnection = new UsbMaskConnection();
         mVideoReader = new VideoReaderExoplayer(fpvView, this);
 
@@ -109,6 +122,7 @@ public class MainActivity extends AppCompatActivity implements UsbDeviceListener
     @Override
     public boolean onTouchEvent(MotionEvent event) {
         gestureDetector.onTouchEvent(event);
+        scaleGestureDetector.onTouchEvent(event);
 
         return super.onTouchEvent(event);
     }

--- a/app/src/main/java/com/fpvout/digiview/VideoReaderExoplayer.java
+++ b/app/src/main/java/com/fpvout/digiview/VideoReaderExoplayer.java
@@ -1,6 +1,7 @@
 package com.fpvout.digiview;
 
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.net.Uri;
 
 import android.os.Handler;
@@ -35,7 +36,9 @@ public class VideoReaderExoplayer {
         private Context context;
         private AndroidUSBInputStream inputStream;
         private UsbMaskConnection mUsbMaskConnection;
-        private boolean zoomedIn = true;
+        private boolean zoomedIn;
+        private SharedPreferences sharedPreferences;
+        private static final String VideoZoomedIn = "VideoZoomedIn";
 
         VideoReaderExoplayer(SurfaceView videoSurface, Context c) {
             surfaceView = videoSurface;
@@ -48,6 +51,9 @@ public class VideoReaderExoplayer {
         }
 
         public void start() {
+            sharedPreferences = context.getSharedPreferences("DigiView", Context.MODE_PRIVATE);
+            zoomedIn = sharedPreferences.getBoolean(VideoZoomedIn, true);
+
             inputStream.startReadThread();
             DefaultLoadControl loadControl = new DefaultLoadControl.Builder().setBufferDurationsMs(32 * 1024, 64 * 1024, 0, 0).build();
             mPlayer = new SimpleExoPlayer.Builder(context).setLoadControl(loadControl).build();
@@ -104,6 +110,10 @@ public class VideoReaderExoplayer {
 
         public void toggleZoom() {
             zoomedIn = !zoomedIn;
+
+            SharedPreferences.Editor preferencesEditor = sharedPreferences.edit();
+            preferencesEditor.putBoolean(VideoZoomedIn, zoomedIn);
+            preferencesEditor.commit();
 
             ConstraintLayout.LayoutParams params = (ConstraintLayout.LayoutParams) surfaceView.getLayoutParams();
 

--- a/app/src/main/java/com/fpvout/digiview/VideoReaderExoplayer.java
+++ b/app/src/main/java/com/fpvout/digiview/VideoReaderExoplayer.java
@@ -9,9 +9,12 @@ import android.util.Log;
 import android.view.SurfaceView;
 import android.widget.Toast;
 
+import androidx.constraintlayout.widget.ConstraintLayout;
+
 import com.google.android.exoplayer2.DefaultLoadControl;
 import com.google.android.exoplayer2.ExoPlaybackException;
 import com.google.android.exoplayer2.ExoPlayer;
+import com.google.android.exoplayer2.Format;
 import com.google.android.exoplayer2.MediaItem;
 import com.google.android.exoplayer2.Player;
 import com.google.android.exoplayer2.SimpleExoPlayer;
@@ -21,6 +24,7 @@ import com.google.android.exoplayer2.source.MediaSource;
 import com.google.android.exoplayer2.source.ProgressiveMediaSource;
 import com.google.android.exoplayer2.upstream.DataSource;
 import com.google.android.exoplayer2.upstream.DataSpec;
+import com.google.android.exoplayer2.video.VideoListener;
 
 import usb.AndroidUSBInputStream;
 
@@ -31,6 +35,7 @@ public class VideoReaderExoplayer {
         private Context context;
         private AndroidUSBInputStream inputStream;
         private UsbMaskConnection mUsbMaskConnection;
+        private boolean zoomedIn = true;
 
         VideoReaderExoplayer(SurfaceView videoSurface, Context c) {
             surfaceView = videoSurface;
@@ -84,6 +89,35 @@ public class VideoReaderExoplayer {
                     }
                 }
             });
+
+            mPlayer.addVideoListener(new VideoListener() {
+                @Override
+                public void onVideoSizeChanged(int width, int height, int unappliedRotationDegrees, float pixelWidthHeightRatio) {
+                    if (!zoomedIn) {
+                        ConstraintLayout.LayoutParams params = (ConstraintLayout.LayoutParams) surfaceView.getLayoutParams();
+                        params.dimensionRatio = width + ":" + height;
+                        surfaceView.setLayoutParams(params);
+                    }
+                }
+            });
+        }
+
+        public void toggleZoom() {
+            zoomedIn = !zoomedIn;
+
+            ConstraintLayout.LayoutParams params = (ConstraintLayout.LayoutParams) surfaceView.getLayoutParams();
+
+            if (zoomedIn) {
+                params.dimensionRatio = "";
+            } else {
+                if (mPlayer == null) return;
+                Format videoFormat = mPlayer.getVideoFormat();
+                if (videoFormat == null) return;
+
+                params.dimensionRatio = videoFormat.width + ":" + videoFormat.height;
+            }
+
+            surfaceView.setLayoutParams(params);
         }
 
         public void restart() {

--- a/app/src/main/java/com/fpvout/digiview/VideoReaderExoplayer.java
+++ b/app/src/main/java/com/fpvout/digiview/VideoReaderExoplayer.java
@@ -43,6 +43,7 @@ public class VideoReaderExoplayer {
         VideoReaderExoplayer(SurfaceView videoSurface, Context c) {
             surfaceView = videoSurface;
             context = c;
+            sharedPreferences = context.getSharedPreferences("DigiView", Context.MODE_PRIVATE);
         }
 
         public void setUsbMaskConnection(UsbMaskConnection connection) {
@@ -51,7 +52,6 @@ public class VideoReaderExoplayer {
         }
 
         public void start() {
-            sharedPreferences = context.getSharedPreferences("DigiView", Context.MODE_PRIVATE);
             zoomedIn = sharedPreferences.getBoolean(VideoZoomedIn, true);
 
             inputStream.startReadThread();
@@ -113,7 +113,7 @@ public class VideoReaderExoplayer {
 
             SharedPreferences.Editor preferencesEditor = sharedPreferences.edit();
             preferencesEditor.putBoolean(VideoZoomedIn, zoomedIn);
-            preferencesEditor.commit();
+            preferencesEditor.apply();
 
             ConstraintLayout.LayoutParams params = (ConstraintLayout.LayoutParams) surfaceView.getLayoutParams();
 
@@ -128,6 +128,18 @@ public class VideoReaderExoplayer {
             }
 
             surfaceView.setLayoutParams(params);
+        }
+
+        public void zoomIn() {
+            if (!zoomedIn) {
+                toggleZoom();
+            }
+        }
+
+        public void zoomOut() {
+            if (zoomedIn) {
+                toggleZoom();
+            }
         }
 
         public void restart() {

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -2,14 +2,16 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/mainLayout"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/black"
+    android:animateLayoutChanges="true"
     tools:context=".MainActivity">
 
     <SurfaceView
         android:id="@+id/fpvView"
-        android:layout_width="match_parent"
+        android:layout_width="0dp"
         android:layout_height="match_parent"
         app:layout_constraintBottom_toTopOf="parent"
         app:layout_constraintEnd_toEndOf="parent"


### PR DESCRIPTION
https://user-images.githubusercontent.com/956646/118441419-79153400-b6e9-11eb-8d65-36f74b8fe687.mov

Resolves #5. Video will start in fullscreen by default as before. Double tap anywhere to switch to its native aspect ratio (unless your device screen and video feed happen to be the same ratio, then there will be no visual effect) with black bars on the edge, double-tap again to return to fullscreen with cropping. I've also enabled auto-animations in the layout, but they look a bit wonky on my Pixel sometimes, I guess resizing SurfaceView while it's playing causes this - any ideas how to avoid it?

Edit: now you can pinch to zoom in/out as well thanks to @omouren ❤️

Switching camera ratio while plugged in will freeze the video and require to plug the USB cable out and back in, tracked under #33.

I'm thinking about enabling full sensor rotation (#20) but disabling fullscreen mode while in portrait since it would look ridiculous, how do you guys feel about that?