### PR TITLE
fix: have overlay show correct png on onResume

### DIFF
--- a/app/src/main/java/com/fpvout/digiview/MainActivity.java
+++ b/app/src/main/java/com/fpvout/digiview/MainActivity.java
@@ -305,7 +305,7 @@ public class MainActivity extends AppCompatActivity implements UsbDeviceListener
                 Log.d(TAG, "APP - On Resume usbDevice device found");
                 connect();
             } else {
-                showOverlay(R.string.waiting_for_usb_device, OverlayStatus.Connected);
+                showOverlay(R.string.waiting_for_usb_device, OverlayStatus.Disconnected);
             }
         }
 


### PR DESCRIPTION
It looks like when `onResume()` was in a "disconnected" state, it was sending `OverlayStatus.Connected` to `showOverlay()` rather than `OverlayStatus.Disconnected`.

Could be wrong about this, I'm decently new to Android/coding in general so please check my work. That being said, my test device was showing the "connected" PNG when disconnected, and this seemed to solve it.

In fact, my device _always_ showed the "connected" PNG, I think because the "disconnected" PNG that was set up in `onCreate()` was immediately being re-drawn by `onResume()`.



**Before changes (on initial start up, fresh install):**
<img width="700" alt="Screen Shot 2021-06-30 at 12 19 54 AM" src="https://user-images.githubusercontent.com/19321892/123919026-55c0e400-d939-11eb-9226-7b3c4ae9f617.png">

**After:**
<img width="714" alt="Screen Shot 2021-06-30 at 12 22 52 AM" src="https://user-images.githubusercontent.com/19321892/123919035-58233e00-d939-11eb-9ac4-6c06efba9d3f.png">


